### PR TITLE
[VIDMC-2584] Use messages api

### DIFF
--- a/vonage-ai-triage-nurse/bot.py
+++ b/vonage-ai-triage-nurse/bot.py
@@ -117,7 +117,7 @@ async def _send_sms_direct(phone: str, message: str) -> dict[str, Any]:
 
     try:
         async with httpx.AsyncClient(timeout=12.0) as client:
-            response = await client.post("https://rest.nexmo.com/sms/json", data=payload)
+            response = await client.post("https://api.vonage.com/v1/messages", data=payload)
             response.raise_for_status()
             data = response.json() if response.text else {}
             first = (data.get("messages") or [{}])[0]

--- a/vonage-ai-triage-nurse/n8n/env.example
+++ b/vonage-ai-triage-nurse/n8n/env.example
@@ -16,6 +16,6 @@ GENERIC_TIMEZONE=UTC
 
 # SMS credentials used inside N8N HTTP Request node
 # Get values from https://dashboard.vonage.com/ -> API Settings
-SMS_API_KEY=YOUR_SMS_API_KEY
-SMS_API_SECRET=YOUR_SMS_API_SECRET
+SMS_API_KEY=YOUR_API_KEY
+SMS_API_SECRET=YOUR_API_SECRET
 SMS_FROM=Vonage APIs

--- a/vonage-ai-triage-nurse/n8n/workflows/vonage-ai-triage-nurse.workflow.json
+++ b/vonage-ai-triage-nurse/n8n/workflows/vonage-ai-triage-nurse.workflow.json
@@ -106,7 +106,7 @@
     {
       "parameters": {
         "method": "POST",
-        "url": "https://rest.nexmo.com/sms/json",
+        "url": "https://api.vonage.com/v1/messages",
         "sendBody": true,
         "contentType": "form-urlencoded",
         "bodyParameters": {


### PR DESCRIPTION
**Summary**
This PR migrates the SMS sending functionality in the vonage-ai-triage-nurse sample application from the legacy Vonage SMS API (https://rest.nexmo.com/sms/json) to the Vonage Messages API (https://api.vonage.com/v1/messages).
The SMS API (rest.nexmo.com/sms/json) is a legacy API being phased out. The Messages API is Vonage's modern omni-channel messaging platform that supports SMS, MMS, RCS, WhatsApp, and more. It also provides higher throughput, JWT authentication support, and application-level webhook configuration.

**Testing**
Tested locally against the Vonage production environment (api.vonage.com) using account API key + secret (Basic Auth)
Verified SMS delivery with a 202 Accepted response and a valid message_uuid in the response body

Related
Jira: [VIDMC-2584](https://jira.vonage.com/browse/VIDMC-2584)
